### PR TITLE
Update YahooOpenIdAttributesDefinition.java

### DIFF
--- a/pac4j-openid/src/main/java/org/pac4j/openid/profile/yahoo/YahooOpenIdAttributesDefinition.java
+++ b/pac4j-openid/src/main/java/org/pac4j/openid/profile/yahoo/YahooOpenIdAttributesDefinition.java
@@ -28,7 +28,7 @@ public class YahooOpenIdAttributesDefinition extends AttributesDefinition {
     
     public static final String EMAIL = "email";
     public static final String LANGUAGE = "language";
-    public static final String FULLNAME = "display_name";
+    public static final String FULLNAME = "fullname";
     public static final String PROFILEPICTURE = "picture_url";
     
     public YahooOpenIdAttributesDefinition() {


### PR DESCRIPTION
Yahoo returns "fullname" attribute instead of "display_name"